### PR TITLE
Hyperlink DOIs against preferred resolver

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ DOIClient
 ===
 [![Apache license](http://img.shields.io/badge/license-Apache-blue.svg?style=flat)](LICENSE) [![Travis](https://travis-ci.org/uc-cdis/doiclient.svg?branch=master)](https://travis-ci.org/uc-cdis/doiclient)
 
-This is the client library for making requests to the dx.doi.org service
+This is the client library for making requests to the doi.org service
 and returning an Indexd compatible document.
 
 

--- a/tests/test_get.py
+++ b/tests/test_get.py
@@ -2,7 +2,7 @@
 def test_get_matsu():
     from doiclient.client import DOIClient
     
-    signpost = DOIClient(baseurl="https://dx.doi.org/")
+    signpost = DOIClient(baseurl="https://doi.org/")
     
     res = signpost.get("10.1007/s41060-017-0052-3")
     res = res.to_json()


### PR DESCRIPTION
Hello :-)

The DOI foundation recommends [this new resolver](https://www.doi.org/doi_handbook/3_Resolution.html#3.8). Yes, a bit ironic that they would change the URL of their service, but it's now [encrypted](https://www.ssllabs.com/ssltest/analyze.html?d=doi.org). Because the old links with the `dx` subdomain continue to work, there is no urgent need to do anything.

However, I'd hereby like to suggest to follow the new recommendation and update the `baseurl`.

Cheers!

PS: Maybe in this repo's description also. Can't change that through a PR ;-)